### PR TITLE
chore(one-to-one): utilise pending state from useActionState

### DIFF
--- a/.changeset/afraid-ants-unite.md
+++ b/.changeset/afraid-ants-unite.md
@@ -1,0 +1,5 @@
+---
+"next-auth-template-one-to-one": minor
+---
+
+chore(one-to-one): utilise pending state from useActionState

--- a/templates/one-to-one/src/components/account-setup-form.tsx
+++ b/templates/one-to-one/src/components/account-setup-form.tsx
@@ -14,7 +14,6 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useActionState, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
-import { useFormStatus } from "react-dom"
 import { useRouter } from "next/navigation"
 import { Loader2 } from "lucide-react"
 import { User } from "@/db/schema/users"
@@ -24,7 +23,7 @@ export function AccountSetupForm({ currentUser }: { currentUser: User }) {
     throw new Error("currentUser has not been passed to AccountSetupForm")
   }
 
-  const [state, formAction] = useActionState(doAccountSetup, undefined)
+  const [state, formAction, isPending] = useActionState(doAccountSetup, undefined)
   const [userName, setUserName] = useState(currentUser.name ?? "")
   const router = useRouter()
 
@@ -53,6 +52,7 @@ export function AccountSetupForm({ currentUser }: { currentUser: User }) {
               type="text"
               value={userName}
               onChange={(e) => setUserName(e.target.value)}
+              disabled={isPending}
               required
               autoFocus
             />
@@ -62,20 +62,12 @@ export function AccountSetupForm({ currentUser }: { currentUser: User }) {
           </div>
         </CardContent>
         <CardFooter className="flex justify-end">
-          <AccountSetupSubmitButton />
+          <Button type="submit" disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Complete sign up
+          </Button>
         </CardFooter>
       </form>
     </Card>
-  )
-}
-
-function AccountSetupSubmitButton() {
-  const { pending } = useFormStatus()
-
-  return (
-    <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-      Complete sign up
-    </Button>
   )
 }

--- a/templates/one-to-one/src/components/magic-sign-in-button.tsx
+++ b/templates/one-to-one/src/components/magic-sign-in-button.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Loader2, CircleX } from "lucide-react"
-import { useFormStatus } from "react-dom"
 import { useActionState, useEffect } from "react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Input } from "@/components/ui/input"
@@ -42,7 +41,7 @@ export function MagicSignInButton() {
 }
 
 function MagicSignInDialogForm() {
-  const [state, formAction] = useActionState(doMagicAuth, undefined)
+  const [state, formAction, isPending] = useActionState(doMagicAuth, undefined)
   const router = useRouter()
 
   useEffect(() => {
@@ -61,47 +60,25 @@ function MagicSignInDialogForm() {
           you can use to sign in without a password.
         </DialogDescription>
       </DialogHeader>
-      <MagicSignInDialogInput disabled={state?.status === "success"} />
+      <div className="w-full my-4">
+        <Label htmlFor="email" className="sr-only">
+          Email
+        </Label>
+        <Input id="email" name="email" className="w-full" disabled={isPending} />
+      </div>
       {state?.messages && <MagicSignInDialogError state={state} />}
       <DialogFooter>
-        <MagicSignInDialogButtons disabled={state?.status === "success"} />
+        <DialogClose asChild>
+          <Button type="button" variant="outline" disabled={isPending}>
+            Cancel
+          </Button>
+        </DialogClose>
+        <Button type="submit" disabled={isPending}>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Send magic link
+        </Button>
       </DialogFooter>
     </form>
-  )
-}
-
-function MagicSignInDialogInput({ disabled }: { disabled?: boolean }) {
-  const { pending } = useFormStatus()
-
-  const isDisabled = pending || disabled ? true : false
-
-  return (
-    <div className="w-full my-4">
-      <Label htmlFor="email" className="sr-only">
-        Email
-      </Label>
-      <Input id="email" name="email" className="w-full" disabled={isDisabled} />
-    </div>
-  )
-}
-
-function MagicSignInDialogButtons({ disabled }: { disabled?: boolean }) {
-  const { pending } = useFormStatus()
-
-  const isDisabled = pending || disabled ? true : false
-
-  return (
-    <>
-      <DialogClose asChild>
-        <Button type="button" variant="outline" disabled={isDisabled}>
-          Cancel
-        </Button>
-      </DialogClose>
-      <Button type="submit" disabled={isDisabled}>
-        {isDisabled && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-        Send magic link
-      </Button>
-    </>
   )
 }
 

--- a/templates/one-to-one/src/components/social-sign-in-button.tsx
+++ b/templates/one-to-one/src/components/social-sign-in-button.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { Loader2 } from "lucide-react"
 import { useActionState } from "react"
-import { useFormStatus } from "react-dom"
 import { doSocialAuth } from "@/actions/auth/do-social-auth"
 
 export function SocialSignInButton({
@@ -17,36 +16,20 @@ export function SocialSignInButton({
   className?: string
   children: React.ReactNode
 }) {
-  const [, formAction] = useActionState(doSocialAuth, undefined)
+  const [, formAction, isPending] = useActionState(doSocialAuth, undefined)
 
   return (
     <form action={formAction}>
       <input type="hidden" name="provider" value={providerName} />
-      <SocialSignInStatefulButton className={className} {...props}>
+        <Button
+        type="submit"
+        className={cn("w-full", className)}
+        {...props}
+        disabled={isPending}
+      >
+        {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
         {children}
-      </SocialSignInStatefulButton>
+      </Button>
     </form>
-  )
-}
-
-function SocialSignInStatefulButton({
-  className,
-  children,
-  ...props
-}: {
-  className?: string
-  children: React.ReactNode
-}) {
-  const { pending } = useFormStatus()
-  return (
-    <Button
-      type="submit"
-      className={cn("w-full", className)}
-      {...props}
-      disabled={pending}
-    >
-      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-      {children}
-    </Button>
   )
 }


### PR DESCRIPTION
With React 19 being used in Next.js stable, we can make full use of `useActionState` rather than relying on `react-dom` to get a forms submission status.